### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -1,5 +1,5 @@
-SevenSegment  KEYWORD1  SSD
-SSD           KEYWORD1  SSD
-reset         KEYWORD2  SSD
-isMaxterm     KEYWORD2  SSD
-displayNibble KEYWORD2  SSD
+SevenSegment	KEYWORD1	SSD
+SSD	KEYWORD1	SSD
+reset	KEYWORD2	SSD
+isMaxterm	KEYWORD2	SSD
+displayNibble	KEYWORD2	SSD


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab, the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords